### PR TITLE
Script tags need closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Many large frameworks have their own state management solutions. One thing these
 Include the following `<script>` tag in the `<head>` of your document:
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/ryangjchandler/spruce@0.x.x/dist/spruce.umd.js">
+<script src="https://cdn.jsdelivr.net/gh/ryangjchandler/spruce@0.x.x/dist/spruce.umd.js"></script>
 ```
 
 > **Important**: This must be added **before** loading Alpine.js when using CDN links.


### PR DESCRIPTION
The CDN script tag example in the readme did not have a ending `</script>` tag so I added one.