### PR TITLE
Simpler import statement to make quickstart more universal

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ export default Spruce
 **app.js**
 
 ```javascript
-import Store from './store'
+import './store'
 import 'alpinejs'
 ```
 


### PR DESCRIPTION
I am using TypeScript and it was a little confusing why it wasn't working. If you don't use `Store` in app.ts it won't include the import so this simpler import statement will be less confusing for beginners