### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "source": "src/index.js",
     "main": "dist/spruce.js",
     "umd:main": "dist/spruce.umd.js",
-    "module": "dist/foo.module.js",
     "scripts": {
         "build": "microbundle",
         "watch": "microbundle watch",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "source": "src/index.js",
     "main": "dist/spruce.js",
     "umd:main": "dist/spruce.umd.js",
+    "module": "dist/spruce.module.js",
     "scripts": {
         "build": "microbundle",
         "watch": "microbundle watch",


### PR DESCRIPTION
when I run 

```
$ parcel build --public-url ./ --no-cache src/pages/*.html
🚨 Build failed.
@parcel/core: Failed to resolve '@ryangjchandler/spruce' from './src/ts/mutable.ts'
@parcel/resolver-default: Could not load './dist/foo.module.js' from module '@ryangjchandler/spruce' found in package.json#module
/home/xk/pomelo/map-scratch-off/node_modules/@ryangjchandler/spruce/package.json:14:15
  13 |     "umd:main": "dist/spruce.umd.js",
> 14 |     "module": "dist/foo.module.js",
>    |               ^^^^^^^^^^^^^^^^^^^^ './dist/foo.module.js' does not exist, did you mean './dist/spruce.module.js'?'

```
it causes my build to fail

probably related to https://github.com/parcel-bundler/parcel/issues/3500
I think it's not a good design choice for parcel v2 but it still is a bug/annoying

I'm not sure what all the implications are for removing this though