### PR TITLE
chore(remove namespace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Include the following `<script>` tag in the `<head>` of your document:
 
 If you wish to include Spruce with your own bundle:
 
-``` bash
-yarn add @ryangjchandler/spruce
+```bash
+yarn add sprucejs
 ```
 
 or:
 
-``` bash
-npm install @ryangjchandler/spruce --save
+```bash
+npm install sprucejs --save
 ```
 
 Then add the following to your script:

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Include the following `<script>` tag in the `<head>` of your document:
 If you wish to include Spruce with your own bundle:
 
 ```bash
-yarn add sprucejs
+yarn add spruce.js
 ```
 
 or:
 
 ```bash
-npm install sprucejs --save
+npm install spruce.js --save
 ```
 
 Then add the following to your script:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@ryangjchandler/spruce",
+    "name": "sprucejs",
     "description": "A lightweight state management layer for Alpine.js",
     "version": "0.6.1",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "sprucejs",
+    "name": "spruce.js",
     "description": "A lightweight state management layer for Alpine.js",
     "version": "0.6.1",
     "repository": {


### PR DESCRIPTION
Closes #43. Removes the `@ryangjchandler` namespace from the package and renames it to `spruce.js`.